### PR TITLE
Fix for change in ChromeDriver version format.

### DIFF
--- a/lib/webdriver_manager/drivers/driver_chrome.rb
+++ b/lib/webdriver_manager/drivers/driver_chrome.rb
@@ -12,7 +12,7 @@ module WebDriverManager
         WebDriverManager.logger.debug(
           "Current version of #{driver_binary} is #{binary_version}"
         )
-        normalize(binary_version.match(/ChromeDriver (\d\.\d+)/)[1])
+        normalize(binary_version.match(/ChromeDriver (\d+\.\d+)/)[1])
       end
 
       def driver_name


### PR DESCRIPTION
As per https://chromedriver.storage.googleapis.com/index.html the latest ChromeDriver version is 70.0.3538.16